### PR TITLE
fix: bulnerability related target="blank"

### DIFF
--- a/components/MainHeader.tsx
+++ b/components/MainHeader.tsx
@@ -66,7 +66,7 @@ export const MainHeader = ({ className, style }: Props) => {
           <Text align="center" size={"sm"}>
             in collaborazione con
           </Text>
-          <a href="https://pagellapolitica.it/">
+          <a href="https://pagellapolitica.it/" target="_blank">
             <Image
               src={`/pagella_politica_logo.svg`}
               alt="Il logo di indecis.it"

--- a/components/MainHeader.tsx
+++ b/components/MainHeader.tsx
@@ -66,7 +66,7 @@ export const MainHeader = ({ className, style }: Props) => {
           <Text align="center" size={"sm"}>
             in collaborazione con
           </Text>
-          <a href="https://pagellapolitica.it/" target="_blank">
+          <a href="https://pagellapolitica.it/" target="_blank" rel="noopener">
             <Image
               src={`/pagella_politica_logo.svg`}
               alt="Il logo di indecis.it"


### PR DESCRIPTION
`All current versions of major browsers now automatically use the behavior of rel="noopener" for any target="_blank" link, nullifying this issue.`

source: https://stackoverflow.com/questions/50709625/link-with-target-blank-and-rel-noopener-noreferrer-still-vulnerable

closes https://github.com/indecis-it/indecis.it/issues/69

forse solo qualche versione vecchia di firefox non supporta noopener (source https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/)