### PR TITLE
[perf] CLS Mitigation

### DIFF
--- a/components/MainHeader.tsx
+++ b/components/MainHeader.tsx
@@ -12,6 +12,10 @@ const useStyles = createStyles((theme) => ({
     alignItems: "self-end",
     flexDirection: "column",
     gap: 0,
+	height: 55,
+	[`@media (min-width: ${theme.breakpoints.md}px)`]: {
+		height: 75,
+	},
   },
   headerGroup: {
     display: "flex",
@@ -23,10 +27,12 @@ const useStyles = createStyles((theme) => ({
     width: "calc(100vw - 80px)",
   },
   logo: {
+    height: 90,
     [`@media (min-width: ${theme.breakpoints.md}px)`]: {
       margin: "0 auto",
       position: "relative",
       left: 80,
+      height: 150
     },
   },
 }));

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,9 @@
+import { createGetInitialProps } from "@mantine/next";
+import Document from "next/document";
+const getInitialProps = createGetInitialProps();
+
+class MyDocument extends Document {
+	static getInitialProps = getInitialProps;
+}
+
+export default MyDocument;


### PR DESCRIPTION
Complimenti per lo splendido progetto!

## Cosa contiene la PR
Consultando il sito durante questi giorni (più volte) ho notato un Layout shifting notevole in fase di caricamento della pagina (es. Homepage)
Mi sono accorto che nell'html prodotto in ssr/ssg da next, il foglio di stile prodotto non contiene le classi css calcolate da `mantine`
Ho semplicemente applicato i passi dalla loro documentazione ([qui](https://mantine.dev/guides/next/)) per ottenere un miglioramento in termini di CLS
Per lo stesso motivo, ho poi cercato di "fissare" delle bounding boxes per i loghi in homepage

## Chrome Profiler
Allego due tracce del profiler di Chrome da poter consultare (prima e dopo)
[ChromeProfileTraces.zip](https://github.com/indecis-it/indecis.it/files/9638307/ChromeProfileTraces.zip)
(Il profiling è stato eseguito sull'attuale sito in produzione ed una build in locale (non dev) di nextjs sulla homepage solo per desktop)

## Lighthouse
L'indice sullo score del CLS viene sensibilmente ridotto su desktop (mentre su mobile è completamente azzerato con questa modifica)
<img width="532" alt="LOCAL_CLS" src="https://user-images.githubusercontent.com/2205037/192089878-d7f73d82-8f73-4e34-85a8-11e38d0d729d.png">
<img width="492" alt="PROD_CLS" src="https://user-images.githubusercontent.com/2205037/192089881-985573e0-a30a-4b1c-b80d-b072afcd07b2.png">


## Cosa resta non risolto?
Potrebbe certo migliorare ancora di molto (es. Modo in cui il componente `Grid` assume una viewport differente - mobile di default) ma sarebbe una modifica più profonda.

### Importante
Unica pecca di queste modifiche è l'aumentare (di poco) dei tempi di SSR (nelle pagine dove è previsto) e del "peso" del file CSS prodotto che la pagina richiede per quelle anche SSG

